### PR TITLE
Support 'block-bound tx'

### DIFF
--- a/cli/query/app_config.go
+++ b/cli/query/app_config.go
@@ -6,13 +6,15 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/amolabs/amo-client-go/cli/util"
+	"github.com/amolabs/amo-client-go/lib/config"
 	"github.com/amolabs/amo-client-go/lib/rpc"
 	"github.com/amolabs/amo-client-go/lib/types"
 )
 
 var AppConfigCmd = &cobra.Command{
 	Use:   "config",
-	Short: "Show config of AMO abci",
+	Short: "Show config of AMO app",
 	RunE:  appConfigFunc,
 }
 
@@ -27,12 +29,19 @@ func appConfigFunc(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// TODO: cache app config somewhere in a storage
 	var appConfig types.AMOAppConfig
 	err = json.Unmarshal([]byte(res), &appConfig)
 	if err != nil {
 		return err
 	}
+
+	cfg, err := config.GetConfig(util.DefaultConfigFilePath())
+	if err != nil {
+		return err
+	}
+
+	cfg.SetABCIConfig(appConfig)
+	cfg.Save()
 
 	fmt.Println(string(res))
 

--- a/cli/query/status.go
+++ b/cli/query/status.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/amolabs/amo-client-go/cli/util"
+	"github.com/amolabs/amo-client-go/lib/config"
 	"github.com/amolabs/amo-client-go/lib/rpc"
 )
 
@@ -14,12 +16,36 @@ var StatusCmd = &cobra.Command{
 	Short: "Show status of AMO node",
 	Long:  "Show status of AMO node including node info, pubkey, latest block hash, app hash, block height and time",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		result, err := rpc.NodeStatus()
+		rawMsg, err := rpc.NodeStatus()
 		if err != nil {
 			return err
 		}
 
-		resultJSON, err := json.MarshalIndent(result, "", "  ")
+		jsonMsg, err := json.Marshal(rawMsg.SyncInfo)
+		if err != nil {
+			return err
+		}
+
+		data := make(map[string]interface{})
+		err = json.Unmarshal(jsonMsg, &data)
+		if err != nil {
+			return err
+		}
+
+		lastHeight := data["latest_block_height"].(string)
+		cfg, err := config.GetConfig(util.DefaultConfigFilePath())
+		if err != nil {
+			return err
+		}
+
+		if lastHeight == "0" {
+			lastHeight = "1"
+		}
+
+		cfg.SetLastHeight(lastHeight)
+		cfg.Save()
+
+		resultJSON, err := json.MarshalIndent(rawMsg, "", "  ")
 		if err != nil {
 			return err
 		}

--- a/cli/tx/cancel.go
+++ b/cli/tx/cancel.go
@@ -29,9 +29,18 @@ func cancelFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	result, err := rpc.Cancel(args[0], key, Fee)
+	lastHeight, err := GetLastHeight(util.DefaultConfigFilePath())
 	if err != nil {
 		return err
+	}
+
+	result, err := rpc.Cancel(args[0], key, Fee, lastHeight)
+	if err != nil {
+		return err
+	}
+
+	if result.Height != "0" {
+		SetLastHeight(util.DefaultConfigFilePath(), result.Height)
 	}
 
 	if asJson {

--- a/cli/tx/delegate.go
+++ b/cli/tx/delegate.go
@@ -29,9 +29,18 @@ func delegateFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	result, err := rpc.Delegate(args[0], args[1], key, Fee)
+	lastHeight, err := GetLastHeight(util.DefaultConfigFilePath())
 	if err != nil {
 		return err
+	}
+
+	result, err := rpc.Delegate(args[0], args[1], key, Fee, lastHeight)
+	if err != nil {
+		return err
+	}
+
+	if result.Height != "0" {
+		SetLastHeight(util.DefaultConfigFilePath(), result.Height)
 	}
 
 	if asJson {

--- a/cli/tx/discard.go
+++ b/cli/tx/discard.go
@@ -29,9 +29,18 @@ func discardFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	result, err := rpc.Discard(args[0], key, Fee)
+	lastHeight, err := GetLastHeight(util.DefaultConfigFilePath())
 	if err != nil {
 		return err
+	}
+
+	result, err := rpc.Discard(args[0], key, Fee, lastHeight)
+	if err != nil {
+		return err
+	}
+
+	if result.Height != "0" {
+		SetLastHeight(util.DefaultConfigFilePath(), result.Height)
 	}
 
 	if asJson {

--- a/cli/tx/grant.go
+++ b/cli/tx/grant.go
@@ -29,9 +29,18 @@ func grantFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	result, err := rpc.Grant(args[0], args[1], args[2], key, Fee)
+	lastHeight, err := GetLastHeight(util.DefaultConfigFilePath())
 	if err != nil {
 		return err
+	}
+
+	result, err := rpc.Grant(args[0], args[1], args[2], key, Fee, lastHeight)
+	if err != nil {
+		return err
+	}
+
+	if result.Height != "0" {
+		SetLastHeight(util.DefaultConfigFilePath(), result.Height)
 	}
 
 	if asJson {

--- a/cli/tx/register.go
+++ b/cli/tx/register.go
@@ -29,9 +29,18 @@ func registerFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	result, err := rpc.Register(args[0], args[1], key, Fee)
+	lastHeight, err := GetLastHeight(util.DefaultConfigFilePath())
 	if err != nil {
 		return err
+	}
+
+	result, err := rpc.Register(args[0], args[1], key, Fee, lastHeight)
+	if err != nil {
+		return err
+	}
+
+	if result.Height != "0" {
+		SetLastHeight(util.DefaultConfigFilePath(), result.Height)
 	}
 
 	if asJson {

--- a/cli/tx/request.go
+++ b/cli/tx/request.go
@@ -29,9 +29,18 @@ func requestFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	result, err := rpc.Request(args[0], args[1], key, Fee)
+	lastHeight, err := GetLastHeight(util.DefaultConfigFilePath())
 	if err != nil {
 		return err
+	}
+
+	result, err := rpc.Request(args[0], args[1], key, Fee, lastHeight)
+	if err != nil {
+		return err
+	}
+
+	if result.Height != "0" {
+		SetLastHeight(util.DefaultConfigFilePath(), result.Height)
 	}
 
 	if asJson {

--- a/cli/tx/retract.go
+++ b/cli/tx/retract.go
@@ -29,9 +29,18 @@ func retractFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	result, err := rpc.Retract(args[0], key, Fee)
+	lastHeight, err := GetLastHeight(util.DefaultConfigFilePath())
 	if err != nil {
 		return err
+	}
+
+	result, err := rpc.Retract(args[0], key, Fee, lastHeight)
+	if err != nil {
+		return err
+	}
+
+	if result.Height != "0" {
+		SetLastHeight(util.DefaultConfigFilePath(), result.Height)
 	}
 
 	if asJson {

--- a/cli/tx/revoke.go
+++ b/cli/tx/revoke.go
@@ -29,9 +29,18 @@ func revokeFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	result, err := rpc.Revoke(args[0], args[1], key, Fee)
+	lastHeight, err := GetLastHeight(util.DefaultConfigFilePath())
 	if err != nil {
 		return err
+	}
+
+	result, err := rpc.Revoke(args[0], args[1], key, Fee, lastHeight)
+	if err != nil {
+		return err
+	}
+
+	if result.Height != "0" {
+		SetLastHeight(util.DefaultConfigFilePath(), result.Height)
 	}
 
 	if asJson {

--- a/cli/tx/stake.go
+++ b/cli/tx/stake.go
@@ -42,9 +42,18 @@ func stakeFunc(cmd *cobra.Command, args []string) error {
 		val = args[0]
 	}
 
-	result, err := rpc.Stake(val, args[1], key, Fee)
+	lastHeight, err := GetLastHeight(util.DefaultConfigFilePath())
 	if err != nil {
 		return err
+	}
+
+	result, err := rpc.Stake(val, args[1], key, Fee, lastHeight)
+	if err != nil {
+		return err
+	}
+
+	if result.Height != "0" {
+		SetLastHeight(util.DefaultConfigFilePath(), result.Height)
 	}
 
 	if asJson {

--- a/cli/tx/transfer.go
+++ b/cli/tx/transfer.go
@@ -30,13 +30,22 @@ func transferFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	result, err := rpc.Transfer(args[0], args[1], key, Fee)
+	lastHeight, err := GetLastHeight(util.DefaultConfigFilePath())
+	if err != nil {
+		return err
+	}
+
+	result, err := rpc.Transfer(args[0], args[1], key, Fee, lastHeight)
 	if err != nil {
 		return err
 	}
 
 	if rpc.DryRun {
 		return nil
+	}
+
+	if result.Height != "0" {
+		SetLastHeight(util.DefaultConfigFilePath(), result.Height)
 	}
 
 	if asJson {

--- a/cli/tx/util.go
+++ b/cli/tx/util.go
@@ -1,0 +1,58 @@
+package tx
+
+import (
+	"encoding/json"
+
+	"github.com/amolabs/amo-client-go/lib/config"
+	"github.com/amolabs/amo-client-go/lib/rpc"
+)
+
+func GetLastHeight(path string) (string, error) {
+	lastHeight := ""
+	cfg, err := config.GetConfig(path)
+	if err != nil {
+		return lastHeight, err
+	}
+
+	lastHeight = cfg.GetLastHeight()
+	if lastHeight == "" {
+		// get lastheight from outside
+		rawMsg, err := rpc.NodeStatus()
+		if err != nil {
+			return lastHeight, err
+		}
+
+		jsonMsg, err := json.Marshal(rawMsg.SyncInfo)
+		if err != nil {
+			return lastHeight, err
+		}
+
+		data := make(map[string]interface{})
+		err = json.Unmarshal(jsonMsg, &data)
+		if err != nil {
+			return lastHeight, err
+		}
+
+		lastHeight = data["latest_block_height"].(string)
+		cfg.SetLastHeight(lastHeight)
+		cfg.Save()
+	}
+
+	return lastHeight, nil
+}
+
+func SetLastHeight(path, lastHeight string) error {
+	cfg, err := config.GetConfig(path)
+	if err != nil {
+		return err
+	}
+
+	cfg.SetLastHeight(lastHeight)
+
+	err = cfg.Save()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cli/tx/withdraw.go
+++ b/cli/tx/withdraw.go
@@ -29,9 +29,18 @@ func withdrawFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	result, err := rpc.Withdraw(args[0], key, Fee)
+	lastHeight, err := GetLastHeight(util.DefaultConfigFilePath())
 	if err != nil {
 		return err
+	}
+
+	result, err := rpc.Withdraw(args[0], key, Fee, lastHeight)
+	if err != nil {
+		return err
+	}
+
+	if result.Height != "0" {
+		SetLastHeight(util.DefaultConfigFilePath(), result.Height)
 	}
 
 	if asJson {

--- a/cli/util/util.go
+++ b/cli/util/util.go
@@ -14,12 +14,17 @@ import (
 
 var (
 	defaultCLIDir      = ".amocli"
+	defaultConfigFile  = "config.json"
 	defaultKeyDir      = "keys"
 	defaultKeyListFile = "keys.json"
 )
 
 func defaultCLIPath() string {
 	return filepath.Join(os.ExpandEnv("$HOME"), defaultCLIDir)
+}
+
+func DefaultConfigFilePath() string {
+	return filepath.Join(defaultCLIPath(), defaultConfigFile)
 }
 
 func DefaultKeyPath() string {
@@ -52,3 +57,31 @@ func PromptPassphrase() (string, error) {
 }
 
 var LineBreak = &cobra.Command{Run: func(*cobra.Command, []string) {}}
+
+func EnsureDir(dir string, mode os.FileMode) error {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		err := os.MkdirAll(dir, mode)
+		if err != nil {
+			return fmt.Errorf("Could not create directory %v. %v", dir, err)
+		}
+	}
+	return nil
+}
+
+func EnsureFile(path string) error {
+	dirPath, _ := filepath.Split(path)
+
+	if len(dirPath) > 0 {
+		err := EnsureDir(dirPath, 0775)
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		return err
+	}
+
+	return err
+}

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -1,0 +1,127 @@
+package config
+
+import (
+	"encoding/json"
+	"io/ioutil"
+
+	"github.com/amolabs/amo-client-go/cli/util"
+	"github.com/amolabs/amo-client-go/lib/rpc"
+	"github.com/amolabs/amo-client-go/lib/types"
+)
+
+type ConfigSet struct {
+	LastHeight string             `json:"last_height"`
+	ABCIConfig types.AMOAppConfig `json:"ABCI_config"`
+	// TODO: CLIConfig would be needed here in the future
+}
+
+type Config struct {
+	filePath  string
+	configSet ConfigSet
+}
+
+func GetConfig(path string) (*Config, error) {
+	cfg := new(Config)
+	cfg.filePath = path
+	cfg.configSet = ConfigSet{}
+	err := cfg.Load()
+	if err != nil {
+		return nil, err
+	}
+
+	if cfg.configSet.LastHeight == "" || cfg.configSet.LastHeight == "0" {
+		err = cfg.updateLastHeight()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return cfg, err
+}
+func (cfg *Config) Load() error {
+	err := util.EnsureFile(cfg.filePath)
+	if err != nil {
+		return err
+	}
+
+	b, err := ioutil.ReadFile(cfg.filePath)
+	if err != nil {
+		return err
+	}
+
+	newConfig := ConfigSet{}
+	if len(b) > 0 {
+		err = json.Unmarshal(b, &newConfig)
+		if err != nil {
+			return err
+		}
+	}
+
+	cfg.configSet = newConfig
+
+	return nil
+}
+
+func (cfg *Config) Save() error {
+	err := util.EnsureFile(cfg.filePath)
+	if err != nil {
+		return err
+	}
+
+	b, err := json.Marshal(cfg.configSet)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(cfg.filePath, b, 0600)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cfg *Config) GetLastHeight() string {
+	return cfg.configSet.LastHeight
+}
+
+func (cfg *Config) SetLastHeight(lastHeight string) {
+	cfg.configSet.LastHeight = lastHeight
+}
+
+func (cfg *Config) GetABCIConfig() types.AMOAppConfig {
+	return cfg.configSet.ABCIConfig
+}
+
+func (cfg *Config) SetABCIConfig(abciConfig types.AMOAppConfig) {
+	cfg.configSet.ABCIConfig = abciConfig
+}
+
+func (cfg *Config) updateLastHeight() error {
+	rawMsg, err := rpc.NodeStatus()
+	if err != nil {
+		return err
+	}
+
+	jsonMsg, err := json.Marshal(rawMsg.SyncInfo)
+	if err != nil {
+		return err
+	}
+
+	data := make(map[string]interface{})
+	err = json.Unmarshal(jsonMsg, &data)
+	if err != nil {
+		return err
+	}
+
+	lastHeight := data["latest_block_height"].(string)
+
+	if lastHeight == "0" {
+		lastHeight = "1"
+	}
+
+	cfg.SetLastHeight(lastHeight)
+	cfg.Save()
+
+	return nil
+}

--- a/lib/keys/keyring.go
+++ b/lib/keys/keyring.go
@@ -5,42 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"os"
-	"path/filepath"
 	"sort"
+
+	"github.com/amolabs/amo-client-go/cli/util"
 )
 
 type KeyRing struct {
 	filePath string
 	keyList  map[string]KeyEntry // just a cache
-}
-
-func EnsureDir(dir string, mode os.FileMode) error {
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		err := os.MkdirAll(dir, mode)
-		if err != nil {
-			return fmt.Errorf("Could not create directory %v. %v", dir, err)
-		}
-	}
-	return nil
-}
-
-func EnsureFile(path string) error {
-	dirPath, _ := filepath.Split(path)
-
-	if len(dirPath) > 0 {
-		err := EnsureDir(dirPath, 0775)
-		if err != nil {
-			return err
-		}
-	}
-
-	_, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0600)
-	if err != nil {
-		return err
-	}
-
-	return err
 }
 
 func GetKeyRing(path string) (*KeyRing, error) {
@@ -55,7 +27,7 @@ func GetKeyRing(path string) (*KeyRing, error) {
 }
 
 func (kr *KeyRing) Load() error {
-	err := EnsureFile(kr.filePath)
+	err := util.EnsureFile(kr.filePath)
 	if err != nil {
 		return err
 	}
@@ -79,7 +51,7 @@ func (kr *KeyRing) Load() error {
 }
 
 func (kr *KeyRing) Save() error {
-	err := EnsureFile(kr.filePath)
+	err := util.EnsureFile(kr.filePath)
 	if err != nil {
 		return err
 	}

--- a/lib/rpc/tx.go
+++ b/lib/rpc/tx.go
@@ -6,87 +6,87 @@ import (
 
 // Tx broadcast in AMO context
 
-func Transfer(to string, amount string, key keys.KeyEntry, fee string) (TmTxResult, error) {
+func Transfer(to string, amount string, key keys.KeyEntry, fee, lastHeight string) (TmTxResult, error) {
 	ret, err := SignSendTx("transfer", struct {
 		To     string `json:"to"`
 		Amount string `json:"amount"`
-	}{to, amount}, key, fee)
+	}{to, amount}, key, fee, lastHeight)
 	return ret, err
 }
 
-func Stake(validator string, amount string, key keys.KeyEntry, fee string) (TmTxResult, error) {
+func Stake(validator string, amount string, key keys.KeyEntry, fee, lastHeight string) (TmTxResult, error) {
 	ret, err := SignSendTx("stake", struct {
 		Validator string `json:"validator"`
 		Amount    string `json:"amount"`
-	}{validator, amount}, key, fee)
+	}{validator, amount}, key, fee, lastHeight)
 	return ret, err
 }
 
-func Withdraw(amount string, key keys.KeyEntry, fee string) (TmTxResult, error) {
+func Withdraw(amount string, key keys.KeyEntry, fee, lastHeight string) (TmTxResult, error) {
 	ret, err := SignSendTx("withdraw", struct {
 		Amount string `json:"amount"`
-	}{amount}, key, fee)
+	}{amount}, key, fee, lastHeight)
 	return ret, err
 }
 
-func Delegate(to string, amount string, key keys.KeyEntry, fee string) (TmTxResult, error) {
+func Delegate(to string, amount string, key keys.KeyEntry, fee, lastHeight string) (TmTxResult, error) {
 	ret, err := SignSendTx("delegate", struct {
 		To     string `json:"to"`
 		Amount string `json:"amount"`
-	}{to, amount}, key, fee)
+	}{to, amount}, key, fee, lastHeight)
 	return ret, err
 }
 
-func Retract(amount string, key keys.KeyEntry, fee string) (TmTxResult, error) {
+func Retract(amount string, key keys.KeyEntry, fee, lastHeight string) (TmTxResult, error) {
 	ret, err := SignSendTx("retract", struct {
 		Amount string `json:"amount"`
-	}{amount}, key, fee)
+	}{amount}, key, fee, lastHeight)
 	return ret, err
 }
 
-func Register(target string, custody string, key keys.KeyEntry, fee string) (TmTxResult, error) {
+func Register(target string, custody string, key keys.KeyEntry, fee, lastHeight string) (TmTxResult, error) {
 	ret, err := SignSendTx("register", struct {
 		Target  string `json:"target"`
 		Custody string `json:"custody"`
-	}{target, custody}, key, fee)
+	}{target, custody}, key, fee, lastHeight)
 	return ret, err
 }
 
-func Discard(target string, key keys.KeyEntry, fee string) (TmTxResult, error) {
+func Discard(target string, key keys.KeyEntry, fee, lastHeight string) (TmTxResult, error) {
 	ret, err := SignSendTx("discard", struct {
 		Target string `json:"target"`
-	}{target}, key, fee)
+	}{target}, key, fee, lastHeight)
 	return ret, err
 }
 
-func Request(target string, payment string, key keys.KeyEntry, fee string) (TmTxResult, error) {
+func Request(target string, payment string, key keys.KeyEntry, fee, lastHeight string) (TmTxResult, error) {
 	ret, err := SignSendTx("request", struct {
 		Target  string `json:"target"`
 		Payment string `json:"payment"`
-	}{target, payment}, key, fee)
+	}{target, payment}, key, fee, lastHeight)
 	return ret, err
 }
 
-func Cancel(target string, key keys.KeyEntry, fee string) (TmTxResult, error) {
+func Cancel(target string, key keys.KeyEntry, fee, lastHeight string) (TmTxResult, error) {
 	ret, err := SignSendTx("cancel", struct {
 		Target string `json:"target"`
-	}{target}, key, fee)
+	}{target}, key, fee, lastHeight)
 	return ret, err
 }
 
-func Grant(target string, grantee string, custody string, key keys.KeyEntry, fee string) (TmTxResult, error) {
+func Grant(target string, grantee string, custody string, key keys.KeyEntry, fee, lastHeight string) (TmTxResult, error) {
 	ret, err := SignSendTx("grant", struct {
 		Target  string `json:"target"`
 		Grantee string `json:"grantee"`
 		Custody string `json:"custody"`
-	}{target, grantee, custody}, key, fee)
+	}{target, grantee, custody}, key, fee, lastHeight)
 	return ret, err
 }
 
-func Revoke(target string, grantee string, key keys.KeyEntry, fee string) (TmTxResult, error) {
+func Revoke(target string, grantee string, key keys.KeyEntry, fee, lastHeight string) (TmTxResult, error) {
 	ret, err := SignSendTx("revoke", struct {
 		Target  string `json:"target"`
 		Grantee string `json:"grantee"`
-	}{target, grantee}, key, fee)
+	}{target, grantee}, key, fee, lastHeight)
 	return ret, err
 }

--- a/lib/types/types.go
+++ b/lib/types/types.go
@@ -95,5 +95,6 @@ type AMOAppConfig struct {
 	LazinessCounterSize  int64   `json:"laziness_counter_size"`
 	LazinessCounterRatio float64 `json:"laziness_counter_ratio"`
 
-	LockupPeriod uint64 `json:"lockup_period"`
+	BlockBoundTxGracePeriod uint64 `json:"block_bound_tx_grace_period"`
+	LockupPeriod            uint64 `json:"lockup_period"`
 }


### PR DESCRIPTION
- cache last_block_height, app_config from amo node
- revise tx struct to contain last_height property

resolves https://github.com/amolabs/amo-client-go/issues/15