### PR TITLE
Prevent remote rpc calling when dry option enabled

### DIFF
--- a/cli/query/delegate.go
+++ b/cli/query/delegate.go
@@ -28,6 +28,10 @@ func delegateFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if rpc.DryRun {
+		return nil
+	}
+
 	if asJson {
 		fmt.Println(string(res))
 		return nil

--- a/cli/query/incentive.go
+++ b/cli/query/incentive.go
@@ -57,6 +57,10 @@ func incentiveFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if rpc.DryRun {
+		return nil
+	}
+
 	if asJson {
 		fmt.Println(string(res))
 		return nil

--- a/cli/query/parcel.go
+++ b/cli/query/parcel.go
@@ -28,6 +28,10 @@ func parcelFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if rpc.DryRun {
+		return nil
+	}
+
 	if asJson {
 		fmt.Println(string(res))
 		return nil

--- a/cli/query/request.go
+++ b/cli/query/request.go
@@ -28,6 +28,10 @@ func requestFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if rpc.DryRun {
+		return nil
+	}
+
 	if asJson {
 		fmt.Println(string(res))
 		return nil

--- a/cli/query/stake.go
+++ b/cli/query/stake.go
@@ -29,6 +29,10 @@ func stakeFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if rpc.DryRun {
+		return nil
+	}
+
 	if asJson {
 		fmt.Println(string(res))
 		return nil

--- a/cli/query/status.go
+++ b/cli/query/status.go
@@ -15,45 +15,52 @@ var StatusCmd = &cobra.Command{
 	Use:   "node",
 	Short: "Show status of AMO node",
 	Long:  "Show status of AMO node including node info, pubkey, latest block hash, app hash, block height and time",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		rawMsg, err := rpc.NodeStatus()
-		if err != nil {
-			return err
-		}
+	RunE:  statusFunc,
+}
 
-		jsonMsg, err := json.Marshal(rawMsg.SyncInfo)
-		if err != nil {
-			return err
-		}
+func statusFunc(cmd *cobra.Command, args []string) error {
+	rawMsg, err := rpc.NodeStatus()
+	if err != nil {
+		return err
+	}
 
-		data := make(map[string]interface{})
-		err = json.Unmarshal(jsonMsg, &data)
-		if err != nil {
-			return err
-		}
-
-		lastHeight := data["latest_block_height"].(string)
-		cfg, err := config.GetConfig(util.DefaultConfigFilePath())
-		if err != nil {
-			return err
-		}
-
-		if lastHeight == "0" {
-			lastHeight = "1"
-		}
-
-		cfg.SetLastHeight(lastHeight)
-		cfg.Save()
-
-		resultJSON, err := json.MarshalIndent(rawMsg, "", "  ")
-		if err != nil {
-			return err
-		}
-
-		fmt.Println(string(resultJSON))
-
+	if rpc.DryRun {
 		return nil
-	},
+	}
+
+	jsonMsg, err := json.Marshal(rawMsg.SyncInfo)
+	if err != nil {
+		return err
+	}
+
+	data := make(map[string]interface{})
+	err = json.Unmarshal(jsonMsg, &data)
+	if err != nil {
+		return err
+	}
+
+	lastHeight := data["latest_block_height"].(string)
+	cfg, err := config.GetConfig(util.DefaultConfigFilePath())
+	if err != nil {
+		return err
+	}
+
+	if lastHeight == "0" {
+		lastHeight = "1"
+	}
+
+	cfg.SetLastHeight(lastHeight)
+	cfg.Save()
+
+	resultJSON, err := json.MarshalIndent(rawMsg, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(resultJSON))
+
+	return nil
+
 }
 
 func init() {

--- a/cli/query/usage.go
+++ b/cli/query/usage.go
@@ -28,6 +28,10 @@ func usageFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if rpc.DryRun {
+		return nil
+	}
+
 	if asJson {
 		fmt.Println(string(res))
 		return nil

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -96,6 +96,10 @@ func (cfg *Config) UpdateLastHeight() error {
 		return err
 	}
 
+	if rpc.DryRun {
+		return nil
+	}
+
 	jsonMsg, err := json.Marshal(rawMsg.SyncInfo)
 	if err != nil {
 		return err


### PR DESCRIPTION
- supplement queries' dry option handling way

resolves https://github.com/amolabs/amo-client-go/issues/21